### PR TITLE
Strings, concatenation, simplified lexer

### DIFF
--- a/internal/ast/expressions/string_literal.go
+++ b/internal/ast/expressions/string_literal.go
@@ -1,0 +1,22 @@
+package expressions
+
+import (
+	"interpreter/internal/lexer/tokens"
+	"interpreter/internal/object"
+)
+
+type StringLiteral struct {
+	Token tokens.Token
+}
+
+func (s *StringLiteral) Literal() string {
+	return s.Token.Literal
+}
+
+func (s *StringLiteral) String() string {
+	return s.Literal()
+}
+
+func (s *StringLiteral) Accept(visitor ExpressionVisitor) object.Object {
+	return visitor.VisitString(s)
+}

--- a/internal/ast/expressions/visitor.go
+++ b/internal/ast/expressions/visitor.go
@@ -11,4 +11,5 @@ type ExpressionVisitor interface {
 	VisitIdentifier(identifier *Identifier) object.Object
 	VisitFunction(function *FunctionLiteral) object.Object
 	VisitCallExpression(call *CallExpression) object.Object
+	VisitString(str *StringLiteral) object.Object
 }

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -58,6 +58,18 @@ func evalInfixIntegerExpression(left, right object.Object, operator tokens.Token
 	}
 }
 
+func evalInfixStringExpression(left, right object.Object, operator tokens.Token) object.Object {
+	leftVal := left.(*object.String).Value
+	rightVal := right.(*object.String).Value
+
+	switch operator.Type {
+	case tokens.PLUS:
+		return &object.String{Value: leftVal + rightVal}
+	default:
+		return newRuntimeError("unknown operator: %s %s %s", left.Type(), operator.Literal, right.Type())
+	}
+}
+
 func evalProgram(statements []statements.Statement, visitor statements.StatementVisitor) object.Object {
 	var result object.Object
 

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -307,3 +307,16 @@ addTwo(2);
 	// 3. Assert
 	testIntegerObject(t, got, 4)
 }
+
+func TestEvaluateStringLiterals(t *testing.T) {
+	// 1. Arrange
+	source := `"hello world"`
+
+	// 2. Act
+	got := testEval(t, source)
+
+	// 3. Assert
+	str, ok := got.(*object.String)
+	require.True(t, ok, "expected a string")
+	require.Equal(t, "hello world", str.Value, "expected literal 'hello world'")
+}

--- a/internal/evaluator/expression_visitor.go
+++ b/internal/evaluator/expression_visitor.go
@@ -116,3 +116,7 @@ func (v *ASTVisitor) VisitCallExpression(call *expressions.CallExpression) objec
 
 	return applyFunction(i.(statements.Statement), v)
 }
+
+func (v *ASTVisitor) VisitString(str *expressions.StringLiteral) object.Object {
+	return &object.String{Value: str.Literal()}
+}

--- a/internal/evaluator/expression_visitor.go
+++ b/internal/evaluator/expression_visitor.go
@@ -54,6 +54,8 @@ func (v *ASTVisitor) VisitInfix(infix *expressions.InfixExpression) object.Objec
 	switch {
 	case left.Type() == object.INTEGER_TYPE && right.Type() == object.INTEGER_TYPE:
 		return evalInfixIntegerExpression(left, right, infix.Token)
+	case left.Type() == object.STRING_TYPE && right.Type() == object.STRING_TYPE:
+		return evalInfixStringExpression(left, right, infix.Token)
 	case left.Type() != right.Type():
 		return newRuntimeError("type mismatch: %s %s %s", left.Type(), infix.Token.Literal, right.Type())
 	default:

--- a/internal/evaluator/tests/evaluator_test.go
+++ b/internal/evaluator/tests/evaluator_test.go
@@ -223,6 +223,10 @@ if (10 > 1) {
 			"foobar",
 			"identifier not found: foobar",
 		},
+		{
+			`"Hello" - "World"`,
+			"unknown operator: STRING - STRING",
+		},
 	} {
 		t.Run(tt.source, func(t *testing.T) {
 			// 1. Act
@@ -254,17 +258,4 @@ func TestLetStatement(t *testing.T) {
 			testIntegerObject(t, got, tt.expected)
 		})
 	}
-}
-
-func TestEvaluateStringLiterals(t *testing.T) {
-	// 1. Arrange
-	source := `"hello world"`
-
-	// 2. Act
-	got := testEval(t, source)
-
-	// 3. Assert
-	str, ok := got.(*object.String)
-	require.True(t, ok, "expected a string")
-	require.Equal(t, "hello world", str.Value, "expected literal 'hello world'")
 }

--- a/internal/evaluator/tests/functions_test.go
+++ b/internal/evaluator/tests/functions_test.go
@@ -22,7 +22,7 @@ func TestFunctionObject(t *testing.T) {
 	require.Equal(t, "(x + 2)", fn.Body.String())
 }
 
-func TestFunctionApplication(t *testing.T) {
+func TestFunctionEvaluation(t *testing.T) {
 	for _, tt := range []struct {
 		source   string
 		expected int64

--- a/internal/evaluator/tests/functions_test.go
+++ b/internal/evaluator/tests/functions_test.go
@@ -1,0 +1,63 @@
+package tests
+
+import (
+	"interpreter/internal/object"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFunctionObject(t *testing.T) {
+	// 1. Arrange
+	source := "fn(x) { x + 2; };"
+
+	// 2. Act
+	got := testEval(t, source)
+
+	// 3. Assert
+	fn, ok := got.(*object.Function)
+	require.True(t, ok, "expected function, but got=%T", got)
+	require.Len(t, fn.Args, 1, "expected one parameter in function")
+	require.Equal(t, "x", fn.Args[0].String(), "parameter is not x")
+	require.Equal(t, "(x + 2)", fn.Body.String())
+}
+
+func TestFunctionApplication(t *testing.T) {
+	for _, tt := range []struct {
+		source   string
+		expected int64
+	}{
+		{"let identity = fn(x) { x; }; identity(5);", 5},
+		{"let identity = fn(x) { return x; }; identity(5);", 5},
+		{"let double = fn(x) { x * 2; }; double(5);", 10},
+		{"let add = fn(x, y) { x + y; }; add(5, 5);", 10},
+		{"let add = fn(x, y) { x + y; }; add(5 + 5, add(5, 5));", 20},
+		{"fn(x) { x; }(5)", 5},
+	} {
+		t.Run(tt.source, func(t *testing.T) {
+			// 1. Arrange
+			got := testEval(t, tt.source)
+
+			// 2. Act
+			testIntegerObject(t, got, tt.expected)
+		})
+	}
+}
+
+func TestClosures(t *testing.T) {
+	// 1. Arrange
+	source := `
+let newAdder = fn(x) {
+	fn(y) { x + y };
+};
+
+let addTwo = newAdder(2);
+addTwo(2);
+`
+
+	// 2. Act
+	got := testEval(t, source)
+
+	// 3. Assert
+	testIntegerObject(t, got, 4)
+}

--- a/internal/evaluator/tests/strings_test.go
+++ b/internal/evaluator/tests/strings_test.go
@@ -1,0 +1,65 @@
+package tests
+
+import (
+	"interpreter/internal/object"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testStringLiteral(t *testing.T, obj object.Object, expectedString string) {
+	str, ok := obj.(*object.String)
+	require.True(t, ok, "expected a string")
+	require.Equalf(t, expectedString, str.Value, "expected literal '%s'", expectedString)
+}
+
+func TestEvaluateStringLiterals(t *testing.T) {
+	// 1. Arrange
+	source := `"hello world"`
+
+	// 2. Act
+	got := testEval(t, source)
+
+	// 3. Assert
+	testStringLiteral(t, got, "hello world")
+}
+
+func TestStringConcatenation(t *testing.T) {
+	for _, tt := range []struct {
+		source   string
+		expected string
+	}{
+		{
+			source:   `""`,
+			expected: "",
+		},
+		{
+			source:   `"" + ""`,
+			expected: "",
+		},
+		{
+			source:   `"" + " " + ""`,
+			expected: " ",
+		},
+		{
+			source:   `"hello" + " " + "world"`,
+			expected: "hello world",
+		},
+		{
+			source:   `"1" + "2" + "3" + "4" + "5"`,
+			expected: "12345",
+		},
+		{
+			source:   `"1"+"2"+"3"+"4"+"5"`,
+			expected: "12345",
+		},
+	} {
+		t.Run(tt.source, func(t *testing.T) {
+			// 1. Act
+			got := testEval(t, tt.source)
+
+			// 2. Assert
+			testStringLiteral(t, got, tt.expected)
+		})
+	}
+}

--- a/internal/lexer/helpers.go
+++ b/internal/lexer/helpers.go
@@ -2,28 +2,10 @@ package lexer
 
 import (
 	"unicode"
-
-	"interpreter/internal/lexer/tokens"
 )
-
-func (l *Lexer) parseWord() (tokens.Token, bool) {
-	if isLetter(l.currentSymbol) {
-		literal := l.readLiteral(isLetter)
-		tokenType := tokens.LookupIdentifierType(literal)
-		return tokens.NewToken(tokenType, literal), true
-	}
-	return tokens.Token{}, false
-}
 
 func isLetter(symbol Symbol) bool {
 	return unicode.IsLetter(symbol)
-}
-
-func (l *Lexer) parseDigit() (tokens.Token, bool) {
-	if isDigit(l.currentSymbol) {
-		return tokens.NewToken(tokens.INT, l.readLiteral(isDigit)), true
-	}
-	return tokens.Token{}, false
 }
 
 func isDigit(symbol Symbol) bool {
@@ -35,6 +17,7 @@ const (
 	tabulation     = '\t'
 	newline        = '\n'
 	carriageReturn = '\r'
+	quot           = '"'
 )
 
 func isNewline(symbol Symbol) bool {

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -99,7 +99,7 @@ func (l *Lexer) NextToken() tokens.Token {
 			token = tokens.NewToken(tokens.COMMA, currentSym)
 		case quot:
 			l.readSymbol()
-			token = tokens.NewToken(tokens.STRING, l.readQuotedString())
+			token = tokens.NewToken(tokens.STRING, l.readStringLiteral())
 		case NULL:
 			return tokens.NewToken(tokens.EOF, "")
 
@@ -119,8 +119,8 @@ func (l *Lexer) NextToken() tokens.Token {
 	}
 }
 
-func (l *Lexer) twoCharToken(sym Symbol, twoCharToken tokens.TokenType, oneCharToken tokens.TokenType) tokens.Token {
-	if l.peekSymbol() == sym {
+func (l *Lexer) twoCharToken(peekSym Symbol, twoCharToken tokens.TokenType, oneCharToken tokens.TokenType) tokens.Token {
+	if l.peekSymbol() == peekSym {
 		ch := l.currentSymbol
 		l.readSymbol()
 		literal := string(ch) + string(l.currentSymbol)
@@ -164,7 +164,7 @@ func (l *Lexer) skipBlockComment() {
 	}
 }
 
-func (l *Lexer) readQuotedString() string {
+func (l *Lexer) readStringLiteral() string {
 	return l.readLiteral(func(symbol Symbol) bool {
 		return symbol != quot
 	})

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -130,6 +130,8 @@ if (5 < 10) {
 
 10 == 10;
 10 != 9;
+"foobar"
+"foo bar"
 `
 
 	tests := []struct {
@@ -217,6 +219,9 @@ if (5 < 10) {
 		{tokens.NOT_EQ, "!="},
 		{tokens.INT, "9"},
 		{tokens.SEMICOLON, ";"},
+
+		{tokens.STRING, "foobar"},
+		{tokens.STRING, "foo bar"},
 
 		{tokens.EOF, ""},
 	}

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -307,3 +307,46 @@ comment
 		})
 	}
 }
+
+func TestNewLine(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		source       string
+		expectedLine int64
+	}{
+		{
+			name:         "empty source - no lines",
+			source:       ``,
+			expectedLine: 1,
+		},
+		{
+			name: "2 lines, but the first one is commented",
+			source: `// some comment
+let x = 2;`,
+			expectedLine: 2,
+		},
+		{
+			name: "many commented lines",
+			source: `// some comment
+// some comment
+// some comment`,
+			expectedLine: 3,
+		},
+		{
+			name:         "first line + 3 newline symbols",
+			source:       "\n\n\n",
+			expectedLine: 4,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			// 1. Arrange
+			l := NewLexer(strings.NewReader(tt.source))
+
+			// 2. Act
+			_ = l.NextToken()
+
+			// 3. Assert
+			require.Equal(t, tt.expectedLine, l.currentLine)
+		})
+	}
+}

--- a/internal/lexer/tokens/token_type.go
+++ b/internal/lexer/tokens/token_type.go
@@ -8,6 +8,7 @@ const (
 
 	// Идентификаторы
 	INT
+	STRING
 	IDENTIFIER
 
 	// Арифметические операторы
@@ -71,11 +72,6 @@ var tokenTypes = map[string]TokenType{
 	"//": COMMENT_LINE,
 	"/*": COMMENT_BEGIN,
 	"*/": COMMENT_END,
-}
-
-func LookupTokenType(literal string) (TokenType, bool) {
-	t, found := tokenTypes[literal]
-	return t, found
 }
 
 var keywords = map[string]TokenType{

--- a/internal/lexer/tokens/token_type.go
+++ b/internal/lexer/tokens/token_type.go
@@ -48,32 +48,6 @@ const (
 	RETURN
 )
 
-var tokenTypes = map[string]TokenType{
-	"=": ASSIGN,
-	"+": PLUS,
-	"-": MINUS,
-	"!": BANG,
-	"*": ASTERISK,
-	"/": SLASH,
-	"<": LT,
-	">": GT,
-
-	"==": EQ,
-	"!=": NOT_EQ,
-
-	",":  COMMA,
-	";":  SEMICOLON,
-	"(":  LPAREN,
-	")":  RPAREN,
-	"{":  LBRACE,
-	"}":  RBRACE,
-	"[":  LBRACKET,
-	"]":  RBRACKET,
-	"//": COMMENT_LINE,
-	"/*": COMMENT_BEGIN,
-	"*/": COMMENT_END,
-}
-
 var keywords = map[string]TokenType{
 	"fn":     FUNCTION,
 	"let":    LET,

--- a/internal/object/object_type.go
+++ b/internal/object/object_type.go
@@ -9,4 +9,5 @@ const (
 	RETURN_TYPE   ObjectType = "RETURN"
 	ERROR_TYPE    ObjectType = "ERROR"
 	FUNCTION_TYPE ObjectType = "FUNCTION"
+	STRING_TYPE   ObjectType = "STRING"
 )

--- a/internal/object/primitive_types.go
+++ b/internal/object/primitive_types.go
@@ -122,3 +122,15 @@ func (f *Function) Inspect() string {
 func (f *Function) Type() ObjectType {
 	return FUNCTION_TYPE
 }
+
+type String struct {
+	Value string
+}
+
+func (s *String) Inspect() string {
+	return s.Value
+}
+
+func (s *String) Type() ObjectType {
+	return STRING_TYPE
+}

--- a/internal/parser/prefix_expression_parsers.go
+++ b/internal/parser/prefix_expression_parsers.go
@@ -23,6 +23,7 @@ func (p *Parser) initPrefixParsers() {
 		tokens.LPAREN:     p.parseGroupedExpression,
 		tokens.IF:         p.parseConditionExpression,
 		tokens.FUNCTION:   p.parseFunction,
+		tokens.STRING:     p.parseStringLiteral,
 	}
 }
 
@@ -167,4 +168,8 @@ func (p *Parser) parseCallArguments() []expressions.Expression {
 	}
 
 	return args
+}
+
+func (p *Parser) parseStringLiteral() expressions.Expression {
+	return &expressions.StringLiteral{Token: p.currentToken}
 }

--- a/internal/parser/tests/expression_test.go
+++ b/internal/parser/tests/expression_test.go
@@ -153,3 +153,16 @@ func testBooleanLiteral(t *testing.T, exp expressions.Expression, expected bool)
 	require.Equal(t, expected, boolean.Value)
 	require.Equal(t, fmt.Sprintf("%t", expected), boolean.Literal())
 }
+
+func TestStringLiteralExpression(t *testing.T) {
+	// 1. Arrange
+	source := `"hello world"`
+
+	// 2. Act
+	statement := parseProgramAndCheckExpression(t, source)
+
+	// 3. Assert
+	str, ok := statement.Value.(*expressions.StringLiteral)
+	require.True(t, ok, "expected a string")
+	require.Equal(t, "hello world", str.Literal(), "expected literal 'hello world'")
+}


### PR DESCRIPTION
## Описание
В данном Pull Request были внедрены строки, а также их конкатенация, используя внутреннюю имплементацию Go. Поскольку host language уже имеет нативную реализацию строк в виде типа `string`, то нет никакого смысла "изобретать колесо" и пытаться самому делать аллокацию памяти под нужную длину символов. Конкатенация стандартная - при сложении двух строк `string1 + string2` выделяется память под новую строку с длиной `len(string1)+len(string2)`, куда копируются все символы.

Также был существенно упрощен лексер, поскольку добавление новой функциональности стало сложнее и менее устойчивой к багам. Добавление новых юнит-тестов помогает отслеживать баги ещё на ранней стадии внедрения фичей в guest language.